### PR TITLE
fixed percent discrepancy with gpu meter and error color.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ const ModeMap = {
             var memory_object = data.nvidia_smi_log.gpu.fb_memory_usage
             var used = parseInt(memory_object.used.replace(' MiB', ''))
             var total = parseInt(memory_object.total.replace(' MiB', ''))
-            var percent = (used / total) * 100
+            var percent = used / total
             resolve(percent)
             }
         });
@@ -128,7 +128,7 @@ class MiniMeter extends q.DesktopApp {
 
   getColor(percent) {
     if (percent < 0 || percent > 1) {
-      return 'black'
+      return '#000000' // Black
     } else {
       return colorsys.hslToHex({
         // hue ranges from blue to red


### PR DESCRIPTION
Just a couple minor things. The percentage for the GPU meter is on a scale 0-100 as opposed to 0-1. That led to an error color of "black" being returned; strings aren't being interpreted as colors so that caused the app to crash. Should be good now!